### PR TITLE
fix(skeleton): exclude poly_norm from forward_memory_only

### DIFF
--- a/src/model/skeleton.py
+++ b/src/model/skeleton.py
@@ -479,15 +479,14 @@ class AtlasMAGSkeleton(nn.Module):
                 mem.w2.weight.flatten(),
                 mem.w3.weight.flatten(),
             ])
-            # Include projection layers and poly_norm for AtlasMemoryPoly
+            # Include projection layers for AtlasMemoryPoly
+            # Note: poly_norm is intentionally excluded - it's normalization
+            # infrastructure, not learned memory content (like a sound engineer's
+            # mixer settings vs. the actual music being recorded)
             if hasattr(mem, 'proj_down'):
                 memory_states.append(mem.proj_down.weight.flatten())
             if hasattr(mem, 'proj_up'):
                 memory_states.append(mem.proj_up.weight.flatten())
-            if hasattr(mem, 'poly_norm'):
-                memory_states.append(mem.poly_norm.weight.flatten())
-                if mem.poly_norm.bias is not None:
-                    memory_states.append(mem.poly_norm.bias.flatten())
 
         memory_state = torch.cat(memory_states)
 


### PR DESCRIPTION
## Summary

- Remove poly_norm parameters from `forward_memory_only` memory state collection
- Add explanatory comment documenting the reasoning

## Rationale

`poly_norm` (LayerNorm) is **normalization infrastructure**, not learned memory content:

| Component | Role | Encodes associations? |
|-----------|------|----------------------|
| w1, w2, w3 | Gated MLP | ✅ Yes |
| proj_down/proj_up | Dimension mapping | ✅ Yes |
| poly_norm | Input normalization | ❌ No |

**Analogy**: poly_norm is like a sound engineer's mixer settings - it enables the memory to work by balancing feature scales, but doesn't encode the "music" (memorized associations) itself.

`forward_memory_only` is used for W_init calibration, which needs to observe learned weights, not normalization parameters.

## Test plan

- [x] All 34 phase1 tests passing
- [x] No functional change to model behavior (poly_norm remains in AtlasMemoryPoly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory state management by refining internal component collection and handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->