### PR TITLE
fix: extend polarization annealing from 10% to 25% of training

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -94,9 +94,9 @@ TTL_RESET_MODE: str = "sequence"
 # Gate Polarization Constants (PRD Section: Gate Polarization)
 # =============================================================================
 
-LAMBDA_INITIAL: float = 1.0       # First 10% of training (reduced from 10.0 per committee feedback)
+LAMBDA_INITIAL: float = 1.0       # First 25% of training (reduced from 10.0 per committee feedback)
 LAMBDA_FINAL: float = 0.01        # After annealing (reduced from 0.1)
-POLARIZATION_ANNEAL_RATIO: float = 0.1  # When to switch from initial to final
+POLARIZATION_ANNEAL_RATIO: float = 0.25  # When to switch from initial to final (extended from 0.1)
 POLARIZATION_WARMUP_STEPS: int = 2000   # Steps before polarization activates (attention head start)
 
 

--- a/src/training/polarization.py
+++ b/src/training/polarization.py
@@ -28,11 +28,12 @@ def get_lambda_polar(step: int, total_steps: int, warmup_steps: int = 0) -> floa
 
     Schedule:
         - Optional warmup: λ = 0.0 for warmup_steps (attention head start)
-        - First 10% of training (post-warmup): λ = LAMBDA_INITIAL
-        - Remaining 90%: Exponential decay λ → LAMBDA_FINAL
+        - First 25% of training (post-warmup): λ = LAMBDA_INITIAL
+        - Remaining 75%: Exponential decay λ → LAMBDA_FINAL
 
-    The high initial λ forces gates to pick a side early. The decay allows
-    nuanced mixing once the architecture has proven it can route.
+    Committee v6 feedback: Extended from 10% to 25% to give modules more time
+    to compete fairly before forcing specialization. The previous aggressive
+    schedule combined with high λ=10 pushed gates to binary values too early.
 
     Args:
         step: Current training step (0-indexed)


### PR DESCRIPTION
## Summary

- Extend polarization annealing period from 10% to 25% of training
- Give modules more time to compete fairly before forcing specialization

## Problem

Committee v6 feedback: The previous aggressive annealing schedule (10%) combined with high λ=10 pushed gates to binary values too early, before modules had a chance to compete fairly.

## Solution

Change `POLARIZATION_ANNEAL_RATIO` from 0.1 to 0.25.

This gives gates 2.5x more time at full polarization pressure (λ=1.0) before decay begins. The decay period (75% of training) is still long enough to allow nuanced mixing after specialization is established.

**Note:** λ was already reduced from 10.0 to 1.0 in a previous update, so this PR only addresses the annealing schedule.

## Test plan

- [x] All phase 1 and phase 3 tests pass (67 tests)
- [x] Docstrings updated to reflect new schedule

Closes #31
Part of #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Extended the initial phase duration in the training pipeline from 10% to 25% of total steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->