### PR TITLE
fix: integrate functional PPL probes into training loop

### DIFF
--- a/src/training/validation.py
+++ b/src/training/validation.py
@@ -3,9 +3,14 @@ Shared validation utilities for Atlas-MAG.
 
 Extracted from train_smollm.py so both the training script and the
 async eval worker can use the same validation logic.
+
+Committee v6 feedback: Added functional PPL probes (memory ON vs OFF)
+to measure actual memory contribution. This replaces brittle unit tests
+that were testing the wrong module.
 """
 
 import math
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -49,3 +54,124 @@ def run_validation(model: nn.Module, loader, device: str) -> dict:
 
     model.train(model_was_training)
     return {"loss": avg_loss, "ppl": ppl, "num_batches": num_batches, "num_tokens": total_tokens}
+
+
+@torch.no_grad()
+def compute_memory_contribution(
+    model: nn.Module,
+    loader,
+    device: str,
+    max_batches: Optional[int] = 4,
+) -> dict:
+    """
+    Compute memory contribution by comparing PPL with memory enabled vs disabled.
+
+    This is a functional end-to-end probe that measures whether memory is actually
+    helping the model. Committee v6 feedback: This replaces brittle unit tests
+    that were testing the wrong module (QK projection instead of AtlasMemoryPoly).
+
+    Formula: memory_contribution_pct = (ppl_nomem - ppl_mem) / ppl_nomem * 100
+    - Positive: memory is helping (lower PPL with memory)
+    - Negative: memory is hurting (higher PPL with memory)
+
+    Args:
+        model: AtlasMAGSkeleton model with .blocks attribute
+        loader: DataLoader yielding dicts with 'input_ids' and 'labels'
+        device: Device string (e.g. 'cuda:0', 'cpu')
+        max_batches: Maximum batches to evaluate (for speed). None = all batches.
+
+    Returns:
+        Dict with keys:
+            - ppl_with_memory: PPL with memory enabled
+            - ppl_without_memory: PPL with memory disabled
+            - memory_contribution_pct: Percentage improvement from memory (positive = helping)
+    """
+    model_was_training = model.training
+    model.train(False)
+
+    # Check if model has blocks attribute (AtlasMAGSkeleton)
+    if not hasattr(model, "blocks"):
+        model.train(model_was_training)
+        return {
+            "ppl_with_memory": 0.0,
+            "ppl_without_memory": 0.0,
+            "memory_contribution_pct": 0.0,
+            "error": "Model does not have .blocks attribute",
+        }
+
+    # Collect batches for consistent comparison
+    batches = []
+    for i, batch in enumerate(loader):
+        if max_batches is not None and i >= max_batches:
+            break
+        batches.append({
+            "input_ids": batch["input_ids"].to(device),
+            "labels": batch["labels"].to(device),
+        })
+
+    if not batches:
+        model.train(model_was_training)
+        return {
+            "ppl_with_memory": 0.0,
+            "ppl_without_memory": 0.0,
+            "memory_contribution_pct": 0.0,
+            "error": "No batches available",
+        }
+
+    # === PPL with memory enabled ===
+    total_loss_mem = 0.0
+    total_tokens = 0
+
+    for batch in batches:
+        logits = model(batch["input_ids"])
+        loss = nn.functional.cross_entropy(
+            logits.view(-1, logits.size(-1)),
+            batch["labels"].view(-1),
+        )
+        total_loss_mem += loss.item() * batch["labels"].numel()
+        total_tokens += batch["labels"].numel()
+
+    avg_loss_mem = total_loss_mem / total_tokens if total_tokens > 0 else float("inf")
+    ppl_with_memory = math.exp(min(avg_loss_mem, 20))
+
+    # === PPL with memory disabled ===
+    # Save original disable_memory flags
+    orig_flags = [block.disable_memory for block in model.blocks]
+
+    try:
+        # Disable memory in all blocks
+        for block in model.blocks:
+            block.disable_memory = True
+
+        total_loss_nomem = 0.0
+
+        for batch in batches:
+            logits = model(batch["input_ids"])
+            loss = nn.functional.cross_entropy(
+                logits.view(-1, logits.size(-1)),
+                batch["labels"].view(-1),
+            )
+            total_loss_nomem += loss.item() * batch["labels"].numel()
+
+        avg_loss_nomem = total_loss_nomem / total_tokens if total_tokens > 0 else float("inf")
+        ppl_without_memory = math.exp(min(avg_loss_nomem, 20))
+
+    finally:
+        # Restore original flags
+        for block, flag in zip(model.blocks, orig_flags):
+            block.disable_memory = flag
+
+    # Compute memory contribution
+    # Positive = memory helping (lower PPL), Negative = memory hurting
+    if ppl_without_memory > 0:
+        memory_contribution_pct = (ppl_without_memory - ppl_with_memory) / ppl_without_memory * 100
+    else:
+        memory_contribution_pct = 0.0
+
+    model.train(model_was_training)
+
+    return {
+        "ppl_with_memory": ppl_with_memory,
+        "ppl_without_memory": ppl_without_memory,
+        "memory_contribution_pct": memory_contribution_pct,
+    }


### PR DESCRIPTION
## Summary

- Add `compute_memory_contribution()` function to measure actual memory contribution
- Integrate into training validation loop
- Log `MemContrib%` alongside PPL during validation

## Problem

Committee v6 feedback: The NIAH probe was testing the wrong module (QK projection instead of AtlasMemoryPoly), producing misleading dashboard signals that looked like memory failure when memory was actually working.

## Solution

Functional end-to-end PPL probes that measure actual memory contribution:

```python
memory_contribution_pct = (ppl_nomem - ppl_mem) / ppl_nomem * 100
```

- **Positive**: memory is helping (lower PPL with memory)
- **Negative**: memory is hurting (higher PPL with memory)

### Example Output

```
[Validation] Loss: 5.95, PPL: 385.2, Train/Val Gap: 1.02x, MemContrib: +1.1%
```

This tells you immediately if memory is working, without needing to understand the internal architecture.

## Test plan

- [x] All 237 tests pass (234 existing + 3 new)
- [x] New tests verify:
  - Function returns expected dict keys
  - Formula is correct
  - Models without `.blocks` return error dict
- [x] Training script imports and uses new function

Closes #32
Part of #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training validation now reports memory contribution metrics in logs, quantifying how memory impacts model performance during periodic and final validation phases.
  * Includes error handling for models lacking required attributes.

* **Tests**
  * Added comprehensive test coverage for memory contribution computation, including result validation and edge case handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->