### PR TITLE
fix: replace SwiGLU with GELU MLP in memory module

### DIFF
--- a/src/model/skeleton.py
+++ b/src/model/skeleton.py
@@ -248,10 +248,10 @@ class AtlasMAGSkeleton(nn.Module):
             if not hasattr(block, "memory"):
                 continue
             mem = block.memory
+            # Paper-compliant 2-projection GELU MLP: M(x) = x + W1(gelu(W2(x)))
             memory_states.extend([
                 mem.w1.weight.flatten(),
                 mem.w2.weight.flatten(),
-                mem.w3.weight.flatten(),
             ])
             if hasattr(mem, "proj_down"):
                 memory_states.append(mem.proj_down.weight.flatten())


### PR DESCRIPTION
## Summary

- Replace SwiGLU-style gated MLP (3 projections) with paper-compliant GELU MLP (2 projections)
- Per Atlas paper (arXiv:2505.23735) Appendix E Section 4: `M(x) = x + W1(σ(W2(x)))` where σ = GELU
- Removes ~786K parameters at 54M scale

## Changes

**Before (SwiGLU-style):**
```python
gate = F.gelu(self.w2(x_mlp_in))
value = self.w3(x_mlp_in)
gated = gate * value
mem_key = self.w1(gated)
```

**After (Paper-compliant GELU MLP):**
```python
hidden = F.gelu(self.w2(x_mlp_in))
mem_key = self.w1(hidden)
```

## Test plan

- [x] All 109 tests pass
- [ ] Restart 125M training run with paper-compliant architecture
- [ ] Compare convergence with previous SwiGLU implementation

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the model's memory MLP to a two-projection GELU design, removing the previous gating pathway for a leaner forward pass.
  * Memory-state assembly streamlined to match the new MLP shape; output normalization and scaling behavior preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->